### PR TITLE
[CHORE]: Fix typo in git config user.mail

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -42,10 +42,11 @@ jobs:
           path: target-repo
           commit-message: "chore: sync shared config from shared-config repo"
           branch: update-shared-config
-          committer: "Enclave Bot <encalve-automation@marvin-fuchs.de>"
-          author: "Enclave Bot <encalve-automation@marvin-fuchs.de>"
+          committer: "Enclave Bot <enclave-automation@marvin-fuchs.de>"
+          author: "Enclave Bot <enclave-automation@marvin-fuchs.de>"
           title: "chore: Sync shared config"
           body: |
+            # Auto-Sync of Shared Config 🏗️ ⚙️
             Automated update from shared-config repo.
 
             This PR syncs the latest shared configuration files.


### PR DESCRIPTION
# Description
This PR fixes a small typo in the sync-actions git email. Maybe this also needs to be changed in the enclave-bot github account settings? 